### PR TITLE
Add test showing the crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "build": "tsc --build",
-    "test:dev": "vitest",
+    "test:dev": "vitest --run direct-stacking-with-bug",
     "test:ci": "jest --bail=1 --silent=false",
     "fmt:check": "./node_modules/.bin/prettier --check .",
     "fmt": "./node_modules/.bin/prettier --write ."

--- a/settings/Devnet.toml
+++ b/settings/Devnet.toml
@@ -30,44 +30,9 @@ balance = 100_000_000_000_000
 # stx_address: ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC
 # btc_address: mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7
 
-[accounts.wallet_4]
-mnemonic = "board list obtain sugar hour worth raven scout denial thunder horse logic fury scorpion fold genuine phrase wealth news aim below celery when cabin"
-balance = 100_000_000_000_000
-# secret_key: f9d7206a47f14d2870c163ebab4bf3e70d18f5d14ce1031f3902fbbc894fe4c701
-# stx_address: ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND
-# btc_address: mg1C76bNTutiCDV3t9nWhZs3Dc8LzUufj8
-
-[accounts.wallet_5]
-mnemonic = "hurry aunt blame peanut heavy update captain human rice crime juice adult scale device promote vast project quiz unit note reform update climb purchase"
-balance = 100_000_000_000_000
-# secret_key: 3eccc5dac8056590432db6a35d52b9896876a3d5cbdea53b72400bc9c2099fe801
-# stx_address: ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB
-# btc_address: mweN5WVqadScHdA81aATSdcVr4B6dNokqx
-
-[accounts.wallet_6]
-mnemonic = "area desk dutch sign gold cricket dawn toward giggle vibrant indoor bench warfare wagon number tiny universe sand talk dilemma pottery bone trap buddy"
-balance = 100_000_000_000_000
-# secret_key: 7036b29cb5e235e5fd9b09ae3e8eec4404e44906814d5d01cbca968a60ed4bfb01
-# stx_address: ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0
-# btc_address: mzxXgV6e4BZSsz8zVHm3TmqbECt7mbuErt
-
-[accounts.wallet_7]
-mnemonic = "prevent gallery kind limb income control noise together echo rival record wedding sense uncover school version force bleak nuclear include danger skirt enact arrow"
-balance = 100_000_000_000_000
-# secret_key: b463f0df6c05d2f156393eee73f8016c5372caa0e9e29a901bb7171d90dc4f1401
-# stx_address: ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ
-# btc_address: n37mwmru2oaVosgfuvzBwgV2ysCQRrLko7
-
-[accounts.wallet_8]
-mnemonic = "female adjust gallery certain visit token during great side clown fitness like hurt clip knife warm bench start reunion globe detail dream depend fortune"
-balance = 100_000_000_000_000
-# secret_key: 6a1a754ba863d7bab14adbbc3f8ebb090af9e871ace621d3e5ab634e1422885e01
-# stx_address: ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP
-# btc_address: n2v875jbJ4RjBnTjgbfikDfnwsDV5iUByw
-
 [accounts.faucet]
 mnemonic = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform"
-balance = 100_000_000_000_000
+balance = 1_000_000_000_000_000
 # secret_key: de433bdfa14ec43aa1098d5be594c8ffb20a31485ff9de2923b2689471c401b801
 # stx_address: STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6
 # btc_address: mjSrB3wS4xab3kYqFktwBzfTdPg367ZJ2d

--- a/tests/integration/constants.ts
+++ b/tests/integration/constants.ts
@@ -42,4 +42,10 @@ export namespace Accounts {
     secretKey:
       "d655b2523bcd65e34889725c73064feb17ceb796831c0e111ba1a552b0f31b3901",
   };
+  export const FAUCET = {
+    stxAddress: "STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6",
+    btcAddress: "mjSrB3wS4xab3kYqFktwBzfTdPg367ZJ2d",
+    secretKey:
+      "de433bdfa14ec43aa1098d5be594c8ffb20a31485ff9de2923b2689471c401b801",
+  };
 }

--- a/tests/integration/pox/helpers-direct-stacking.ts
+++ b/tests/integration/pox/helpers-direct-stacking.ts
@@ -7,7 +7,7 @@ import {
   bufferCV,
   makeContractCall,
   tupleCV,
-  uintCV
+  uintCV,
 } from "@stacks/transactions";
 import { Contracts } from "../constants";
 
@@ -62,14 +62,11 @@ export const broadcastStackIncrease = async (
   fee: number,
   nonce: number
 ): Promise<TxBroadcastResult> => {
-
   const txOptions = {
     contractAddress: Contracts.POX_2.address,
     contractName: Contracts.POX_2.name,
     functionName: "stack-increase",
-    functionArgs: [
-      uintCV(amount),
-    ],
+    functionArgs: [uintCV(amount)],
     fee,
     nonce,
     network,
@@ -100,10 +97,7 @@ export const broadcastStackExtend = async (
     contractAddress: Contracts.POX_2.address,
     contractName: Contracts.POX_2.name,
     functionName: "stack-extend",
-    functionArgs: [
-      tupleCV(address),
-      uintCV(cycles),
-    ],
+    functionArgs: [tupleCV(address), uintCV(cycles)],
     fee,
     nonce,
     network,

--- a/tests/integration/pox/stacking/direct-stacking-good-order.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-good-order.spec.ts
@@ -110,7 +110,7 @@ describe("testing solo stacker increase without bug", () => {
     const poxAddrInfo0 = await readRewardCyclePoxAddressList(network, 2, 0);
     const poxAddrInfo0CV = hexToCV(poxAddrInfo0.data) as SomeCV<TupleCV>;
     const poxAddrInfoStr0 = cvToString(hexToCV(poxAddrInfo0.data));
-    // There is no bug here because total stack was 0 when stack-increase was called.
+    // There is no bug here because total stack was equal to Bob's stacked amount when Bob called stack-increase.
     expect(cvToString(poxAddrInfo0CV.value.data["total-ustx"])).toBe(
       "u50000000000110"
     );

--- a/tests/integration/pox/stacking/direct-stacking-good-order.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-good-order.spec.ts
@@ -1,0 +1,122 @@
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
+import { StacksTestnet } from "@stacks/network";
+import { Accounts } from "../../constants";
+import {
+  buildDevnetNetworkOrchestrator,
+  getNetworkIdFromEnv,
+  waitForStacksTransaction,
+} from "../../helpers";
+import {
+  getPoxInfo,
+  waitForNextRewardPhase,
+  waitForRewardCycleId,
+  readRewardCyclePoxAddressList,
+} from "../helpers";
+import {
+  broadcastStackIncrease,
+  broadcastStackSTX,
+} from "../helpers-direct-stacking";
+import {
+  OptionalCV,
+  SomeCV,
+  TupleCV,
+  cvToString,
+  hexToCV,
+} from "@stacks/transactions";
+
+describe("testing solo stacker increase without bug", () => {
+  let orchestrator: DevnetNetworkOrchestrator;
+  let timeline = {
+    epoch_2_0: 100,
+    epoch_2_05: 102,
+    epoch_2_1: 106,
+    pox_2_activation: 109,
+  };
+
+  beforeAll(() => {
+    orchestrator = buildDevnetNetworkOrchestrator(getNetworkIdFromEnv());
+    orchestrator.start();
+  });
+
+  afterAll(() => {
+    orchestrator.terminate();
+  });
+
+  it("using stacks-increase in the same cycle should result in increased rewards", async () => {
+    const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
+
+    // Wait for Stacks genesis block
+    await orchestrator.waitForNextStacksBlock();
+    // Wait for block N+1 where N is the height of the next reward phase
+    await waitForNextRewardPhase(network, orchestrator, 1);
+
+    const blockHeight = timeline.pox_2_activation + 1;
+    const fee = 1000;
+    const cycles = 1;
+
+    // Bob stacks 30m
+    let response = await broadcastStackSTX(
+      2,
+      network,
+      30_000_000_000_010,
+      Accounts.WALLET_2,
+      blockHeight,
+      cycles,
+      fee,
+      0
+    );
+    expect(response.error).toBeUndefined();
+
+    // Bob increases by 20m
+    response = await broadcastStackIncrease(
+      network,
+      20_000_000_000_100,
+      Accounts.WALLET_2,
+      fee,
+      1
+    );
+    expect(response.error).toBeUndefined();
+
+    // let Bob's stacking confirm to enforce reward index 0
+    await waitForStacksTransaction(orchestrator, response.txid);
+
+    // Alice stacks 50m
+    response = await broadcastStackSTX(
+      2,
+      network,
+      50_000_000_000_001,
+      Accounts.WALLET_1,
+      blockHeight,
+      cycles,
+      fee,
+      0
+    );
+    expect(response.error).toBeUndefined();
+
+    await orchestrator.waitForStacksBlockIncludingTransaction(response.txid);
+    let poxInfo = await getPoxInfo(network);
+
+    // Asserts about pox info for better knowledge sharing
+    expect(poxInfo.contract_id).toBe("ST000000000000000000002AMW42H.pox-2");
+    expect(poxInfo.pox_activation_threshold_ustx).toBe(50_286_942_145_278);
+    expect(poxInfo.current_cycle.id).toBe(1);
+    expect(poxInfo.current_cycle.min_threshold_ustx).toBe(20_960_000_000_000);
+
+    // Assert that the next cycle has 100m STX locked
+    expect(poxInfo.current_cycle.stacked_ustx).toBe(0);
+    expect(poxInfo.current_cycle.is_pox_active).toBe(false);
+    expect(poxInfo.next_cycle.stacked_ustx).toBe(100_000_000_000_111);
+
+    const poxAddrInfo0 = await readRewardCyclePoxAddressList(network, 2, 0);
+    const poxAddrInfo0CV = hexToCV(poxAddrInfo0.data) as SomeCV<TupleCV>;
+    const poxAddrInfoStr0 = cvToString(hexToCV(poxAddrInfo0.data));
+    // There is no bug here because total stack was 0 when stack-increase was called.
+    expect(cvToString(poxAddrInfo0CV.value.data["total-ustx"])).toBe(
+      "u50000000000110"
+    );
+
+    const poxAddrInfo1 = await readRewardCyclePoxAddressList(network, 2, 1);
+    const poxAddrInfoStr1 = cvToString(hexToCV(poxAddrInfo1.data));
+    expect(poxAddrInfoStr1).toContain("(total-ustx u50000000000001)");
+  });
+});

--- a/tests/integration/pox/stacking/direct-stacking-with-bug.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-with-bug.spec.ts
@@ -1,0 +1,162 @@
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
+import { StacksTestnet } from "@stacks/network";
+import {
+  SomeCV,
+  TupleCV,
+  UIntCV,
+  cvToString,
+  hexToCV,
+} from "@stacks/transactions";
+import { Accounts } from "../../constants";
+import {
+  buildDevnetNetworkOrchestrator,
+  getNetworkIdFromEnv,
+  waitForStacksTransaction,
+} from "../../helpers";
+import {
+  getPoxInfo,
+  readRewardCyclePoxAddressList,
+  waitForNextRewardPhase,
+} from "../helpers";
+import {
+  broadcastStackIncrease,
+  broadcastStackSTX,
+} from "../helpers-direct-stacking";
+
+describe("testing solo stacker increase without bug", () => {
+  let orchestrator: DevnetNetworkOrchestrator;
+  let timeline = {
+    epoch_2_0: 100,
+    epoch_2_05: 102,
+    epoch_2_1: 106,
+    pox_2_activation: 109,
+  };
+
+  beforeAll(() => {
+    orchestrator = buildDevnetNetworkOrchestrator(getNetworkIdFromEnv());
+    orchestrator.start();
+  });
+
+  afterAll(() => {
+    orchestrator.terminate();
+  });
+
+  it("using stacks-increase in the same cycle should result in increased rewards", async () => {
+    const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
+
+    // Wait for Stacks genesis block
+    await orchestrator.waitForNextStacksBlock();
+    // Wait for block N+1 where N is the height of the next reward phase
+    await waitForNextRewardPhase(network, orchestrator, 1);
+
+    const blockHeight = timeline.pox_2_activation + 1;
+    const fee = 1000;
+    const cycles = 1;
+
+    // Alice stacks 900m (1/4 of liquid suply)
+    let response = await broadcastStackSTX(
+      2,
+      network,
+      900_000_000_000_001,
+      Accounts.FAUCET,
+      blockHeight,
+      cycles,
+      fee,
+      0
+    );
+    expect(response.error).toBeUndefined();
+
+    // let Alice's stacking confirm to enforce reward index 0
+    await waitForStacksTransaction(orchestrator, response.txid);
+
+    // Bob stacks 80m
+    response = await broadcastStackSTX(
+      2,
+      network,
+      80_000_000_000_010,
+      Accounts.WALLET_2,
+      blockHeight,
+      cycles,
+      fee,
+      0
+    );
+    expect(response.error).toBeUndefined();
+
+    // Bob increases by 10m
+    response = await broadcastStackIncrease(
+      network,
+      10_000_000_000_100,
+      Accounts.WALLET_2,
+      fee,
+      1
+    );
+    expect(response.error).toBeUndefined();
+    // let Bobx's stacking confirm to enforce reward index 1
+    await waitForStacksTransaction(orchestrator, response.txid);
+
+    // Cloe stacks 80m
+    response = await broadcastStackSTX(
+      2,
+      network,
+      80_000_000_001_000,
+      Accounts.WALLET_3,
+      blockHeight,
+      cycles,
+      fee,
+      0
+    );
+    expect(response.error).toBeUndefined();
+
+    // Cloe increases by 10m
+    response = await broadcastStackIncrease(
+      network,
+      10_000_000_010_000,
+      Accounts.WALLET_3,
+      fee,
+      1
+    );
+    expect(response.error).toBeUndefined();
+    await orchestrator.waitForStacksBlockIncludingTransaction(response.txid);
+   
+    let poxInfo = await getPoxInfo(network);
+
+    // Asserts about pox info for better knowledge sharing
+    expect(poxInfo.total_liquid_supply_ustx).toBe(1_405_738_842_905_579);
+    expect(poxInfo.contract_id).toBe("ST000000000000000000002AMW42H.pox-2");
+    expect(poxInfo.pox_activation_threshold_ustx).toBe(70_286_942_145_278);
+    expect(poxInfo.current_cycle.id).toBe(1);
+    expect(poxInfo.current_cycle.min_threshold_ustx).toBe(29_290_000_000_000);
+
+    // Assert that the next cycle has 100m STX locked
+    expect(poxInfo.current_cycle.stacked_ustx).toBe(0);
+    expect(poxInfo.current_cycle.is_pox_active).toBe(false);
+    expect(poxInfo.next_cycle.stacked_ustx).toBe(1_080_000_000_011_111);
+
+    // Check Alice's table entry
+    const poxAddrInfo0 = await readRewardCyclePoxAddressList(network, 2, 0);
+    const poxAddrInfo0CV = hexToCV(poxAddrInfo0.data) as SomeCV<TupleCV>;
+    expect((poxAddrInfo0CV.value.data["total-ustx"] as UIntCV).value).toBe(
+      BigInt(900_000_000_000_001)
+    );
+
+    // Check Bob's table entry
+    const poxAddrInfo1 = await readRewardCyclePoxAddressList(network, 2, 1);
+    const poxAddrInfo1CV = hexToCV(poxAddrInfo1.data) as SomeCV<TupleCV>;
+    // HERE'S THE BUG: THIS SHOULD BE `u90000000000110`
+    // expect(cvToString(poxAddrInfo1CV.value.data["total-ustx"])).toBe("u90000000000110");
+    expect((poxAddrInfo1CV.value.data["total-ustx"] as UIntCV).value).toBe(
+      BigInt(990_000_000_000_111)
+    );
+    // Check Cloe's table entry
+    const poxAddrInfo2 = await readRewardCyclePoxAddressList(network, 2, 2);
+    const poxAddrInfo2CV = hexToCV(poxAddrInfo2.data) as SomeCV<TupleCV>;
+    // HERE'S THE BUG: THIS SHOULD BE `u90000000011000`
+    // expect(cvToString(poxAddrInfo1CV.value.data["total-ustx"])).toBe("u90000000011000");
+    expect((poxAddrInfo2CV.value.data["total-ustx"] as UIntCV).value).toBe(
+      BigInt(1080_000_000_011_111)
+    );
+
+    const update = await waitForNextRewardPhase(network, orchestrator, 5);
+    console.log(update)
+  });
+});

--- a/tests/integration/pox/stacking/epoch_2_1.spec.ts
+++ b/tests/integration/pox/stacking/epoch_2_1.spec.ts
@@ -9,9 +9,7 @@ import {
   getPoxInfo,
   waitForRewardCycleId,
 } from "../helpers";
-import {
-  broadcastStackSTX,
-} from "../helpers-direct-stacking";
+import { broadcastStackSTX } from "../helpers-direct-stacking";
 import { Accounts } from "../../constants";
 import { StacksTestnet } from "@stacks/network";
 import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
@@ -94,6 +92,6 @@ describe("testing stacking under epoch 2.1", () => {
     // Assert
     expect(poxInfo.contract_id).toBe("ST000000000000000000002AMW42H.pox-2");
     expect(poxInfo.current_cycle.is_pox_active).toBe(true);
-    expect(poxInfo.total)
+    expect(poxInfo.total);
   });
 });

--- a/tests/integration/pox/stacking/pooled-stacking-extend.spec.ts
+++ b/tests/integration/pox/stacking/pooled-stacking-extend.spec.ts
@@ -1,0 +1,132 @@
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
+import { StacksTestnet } from "@stacks/network";
+import { Accounts } from "../../constants";
+import {
+  buildDevnetNetworkOrchestrator,
+  getNetworkIdFromEnv,
+  waitForStacksTransaction,
+} from "../../helpers";
+import {
+  expectNoError,
+  getPoxInfo,
+  waitForNextRewardPhase,
+  waitForRewardCycleId,
+} from "../helpers";
+import {
+  broadcastDelegateSTX,
+  broadcastDelegateStackExtend,
+  broadcastDelegateStackIncrease,
+  broadcastDelegateStackSTX,
+  broadcastStackAggregationCommitIndexed,
+  broadcastStackAggregationIncrease,
+} from "../helpers-pooled-stacking";
+
+describe("testing pooled stacking under epoch 2.1", () => {
+  let orchestrator: DevnetNetworkOrchestrator;
+  let timeline = {
+    epoch_2_0: 100,
+    epoch_2_05: 102,
+    epoch_2_1: 106,
+    pox_2_activation: 109,
+  };
+
+  beforeAll(() => {
+    orchestrator = buildDevnetNetworkOrchestrator(getNetworkIdFromEnv());
+    orchestrator.start();
+  });
+
+  afterAll(() => {
+    orchestrator.terminate();
+  });
+  
+  it("pool operators can lock user's locked stx for longer", async () => {
+    const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
+
+    // Wait for Stacks genesis block
+    await orchestrator.waitForNextStacksBlock();
+    // Wait for block N+1 where N is the height of the next reward phase
+    await waitForNextRewardPhase(network, orchestrator, 1);
+    const fee = 1000;
+
+    // Alice delegates 70m STX
+    let response = await broadcastDelegateSTX(
+      2,
+      network,
+      Accounts.WALLET_1,
+      fee,
+      2, // nonce 1 used in second test
+      70_000_000_000_000,
+      Accounts.WALLET_3
+    );
+    expectNoError(response);
+
+    // Cloe locks 70m for Alice for 1 cycle
+    response = await broadcastDelegateStackSTX(
+      2,
+      network,
+      Accounts.WALLET_3,
+      fee,
+      7,
+      Accounts.WALLET_1,
+      70_000_000_000_000,
+      Accounts.WALLET_3,
+      timeline.pox_2_activation + 6,
+      1
+    );
+    expectNoError(response);
+
+    // Cloe locks extends Alice's locking for 1 cycle
+    response = await broadcastDelegateStackExtend(
+      2,
+      network,
+      Accounts.WALLET_3,
+      fee,
+      8,
+      Accounts.WALLET_1,
+      Accounts.WALLET_3,
+      1
+    );
+    expectNoError(response);
+
+    // Cloe commits 70m
+    response = await broadcastStackAggregationCommitIndexed(
+      2,
+      network,
+      Accounts.WALLET_3,
+      fee,
+      9,
+      Accounts.WALLET_3,
+      2
+    );
+    expectNoError(response);
+
+    let [block, tx] = await waitForStacksTransaction(
+      orchestrator,
+      response.txid
+    );
+    expect(tx.result).toBe("(ok 1)");
+    expect(tx.success).toBeTruthy();
+
+    let poxInfo = await getPoxInfo(network);
+
+    // Assert that the next cycle has 70m STX locked
+    expect(poxInfo.current_cycle.stacked_ustx).toBe(0);
+    expect(poxInfo.current_cycle.is_pox_active).toBe(false);
+    expect(poxInfo.next_cycle.stacked_ustx).toBe(0); // TODO 70_000_000_000_000
+
+    // move on to the nexte cycle
+    await waitForRewardCycleId(network, orchestrator, 9, 1);
+
+    poxInfo = await getPoxInfo(network);
+    // Assert that the current cycle has 70m STX locked and earning
+    expect(poxInfo.current_cycle.id).toBe(9);
+    expect(poxInfo.current_cycle.stacked_ustx).toBe(0); // TODO 70_000_000_000_000
+    expect(poxInfo.current_cycle.is_pox_active).toBe(false);
+
+    // move on to the nexte cycle
+    await waitForNextRewardPhase(network, orchestrator, 1);
+
+    // Assert reward slots
+    // TODO
+  });
+});

--- a/tests/integration/pox/stacking/pooled-stacking-extend.spec.ts
+++ b/tests/integration/pox/stacking/pooled-stacking-extend.spec.ts
@@ -38,7 +38,7 @@ describe("testing pooled stacking under epoch 2.1", () => {
   afterAll(() => {
     orchestrator.terminate();
   });
-  
+
   it("pool operators can lock user's locked stx for longer", async () => {
     const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
 


### PR DESCRIPTION
This PR
* changes the settings for devnet so that 1 user (faucet) owns most of the liquidity.
* adds a test that makes the network halt
* `yarn dev:test` runs only test showing the bug

TODO:
* properly assert the halt of the network
* update other tests to new devnet setttings


![image](https://user-images.githubusercontent.com/1449049/233776121-cff1031c-3753-47ec-829c-3cc3ee276ac4.png)
