### PR TITLE
feat: improve helpers for reading pox address info

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,15 @@ Public repository of tests focused on checking the new features coming with the 
 
 ```bash
 yarn install
-yarn test-ui
+yarn test:dev
+```
+
+To run tests from one file, use:
+```
+yarn vitest --run direct-stacking-with-bug
+```
+
+Or to run a specific test, use the `-t` flag to specify the complete name:
+```
+yarn test:dev run -t "using stacks-increase in the same cycle should result in increased rewards"
 ```

--- a/tests/integration/pox/stacking/direct-stacking-good-order.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-good-order.spec.ts
@@ -91,9 +91,7 @@ describe("testing solo stacker increase without bug", () => {
 
     // Asserts about pox info for better knowledge sharing
     expect(poxInfo.contract_id).toBe("ST000000000000000000002AMW42H.pox-2");
-    // expect(poxInfo.pox_activation_threshold_ustx).toBe(50_286_942_145_278);
     expect(poxInfo.current_cycle.id).toBe(1);
-    // expect(poxInfo.current_cycle.min_threshold_ustx).toBe(20_960_000_000_000);
 
     // Assert that the next cycle has 100m STX locked
     expect(poxInfo.current_cycle.stacked_ustx).toBe(0);

--- a/tests/integration/pox/stacking/direct-stacking-with-bug.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-with-bug.spec.ts
@@ -1,6 +1,6 @@
 import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
-import { ClarityValue, UIntCV } from "@stacks/transactions";
+import { ClarityValue, UIntCV, uintCV } from "@stacks/transactions";
 import { Accounts } from "../../constants";
 import {
   buildDevnetNetworkOrchestrator,
@@ -134,8 +134,8 @@ describe("testing solo stacker increase without bug", () => {
       2,
       Accounts.FAUCET.stxAddress
     )) as Record<string, ClarityValue>;
-    expect((poxAddrInfo0["total-ustx"] as UIntCV).value).toBe(
-      BigInt(900_000_000_000_001)
+    expect((poxAddrInfo0["total-ustx"] as UIntCV).value).toEqual(
+      uintCV(900_000_000_000_001)
     );
 
     // Check Bob's table entry
@@ -145,10 +145,13 @@ describe("testing solo stacker increase without bug", () => {
       Accounts.WALLET_2.stxAddress
     )) as Record<string, ClarityValue>;
     // HERE'S THE BUG: THIS SHOULD BE `u90000000000110`
-    // expect(cvToString(poxAddrInfo1CV.value.data["total-ustx"])).toBe("u90000000000110");
-    expect((poxAddrInfo1["total-ustx"] as UIntCV).value).toBe(
-      BigInt(990_000_000_000_111)
+    // expect((poxAddrInfo1["total-ustx"] as UIntCV).value).toEqual(
+    //   uintCV(90_000_000_000_110)
+    // );
+    expect((poxAddrInfo1["total-ustx"] as UIntCV).value).toEqual(
+      uintCV(900_000_000_000_111)
     );
+
     // Check Cloe's table entry
     const poxAddrInfo2 = (await readRewardCyclePoxAddressForAddress(
       network,

--- a/tests/integration/pox/stacking/direct-stacking-with-bug.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-with-bug.spec.ts
@@ -1,12 +1,6 @@
 import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
-import {
-  SomeCV,
-  TupleCV,
-  UIntCV,
-  cvToString,
-  hexToCV,
-} from "@stacks/transactions";
+import { ClarityValue, UIntCV } from "@stacks/transactions";
 import { Accounts } from "../../constants";
 import {
   buildDevnetNetworkOrchestrator,
@@ -17,8 +11,7 @@ import {
   getCoreInfo,
   getPoxInfo,
   mineBtcBlock as mineBitcoinBlockAndHopeForStacksBlock,
-  readRewardCyclePoxAddressList,
-  waitForNextPreparePhase,
+  readRewardCyclePoxAddressForAddress,
   waitForNextRewardPhase,
 } from "../helpers";
 import {
@@ -136,26 +129,35 @@ describe("testing solo stacker increase without bug", () => {
     expect(poxInfo.next_cycle.stacked_ustx).toBe(1_080_000_000_011_111);
 
     // Check Alice's table entry
-    const poxAddrInfo0 = await readRewardCyclePoxAddressList(network, 2, 0);
-    const poxAddrInfo0CV = hexToCV(poxAddrInfo0.data) as SomeCV<TupleCV>;
-    expect((poxAddrInfo0CV.value.data["total-ustx"] as UIntCV).value).toBe(
+    const poxAddrInfo0 = (await readRewardCyclePoxAddressForAddress(
+      network,
+      2,
+      Accounts.FAUCET.stxAddress
+    )) as Record<string, ClarityValue>;
+    expect((poxAddrInfo0["total-ustx"] as UIntCV).value).toBe(
       BigInt(900_000_000_000_001)
     );
 
     // Check Bob's table entry
-    const poxAddrInfo1 = await readRewardCyclePoxAddressList(network, 2, 1);
-    const poxAddrInfo1CV = hexToCV(poxAddrInfo1.data) as SomeCV<TupleCV>;
+    const poxAddrInfo1 = (await readRewardCyclePoxAddressForAddress(
+      network,
+      2,
+      Accounts.WALLET_2.stxAddress
+    )) as Record<string, ClarityValue>;
     // HERE'S THE BUG: THIS SHOULD BE `u90000000000110`
     // expect(cvToString(poxAddrInfo1CV.value.data["total-ustx"])).toBe("u90000000000110");
-    expect((poxAddrInfo1CV.value.data["total-ustx"] as UIntCV).value).toBe(
+    expect((poxAddrInfo1["total-ustx"] as UIntCV).value).toBe(
       BigInt(990_000_000_000_111)
     );
     // Check Cloe's table entry
-    const poxAddrInfo2 = await readRewardCyclePoxAddressList(network, 2, 2);
-    const poxAddrInfo2CV = hexToCV(poxAddrInfo2.data) as SomeCV<TupleCV>;
+    const poxAddrInfo2 = (await readRewardCyclePoxAddressForAddress(
+      network,
+      2,
+      Accounts.WALLET_3.stxAddress
+    )) as Record<string, ClarityValue>;
     // HERE'S THE BUG: THIS SHOULD BE `u90000000011000`
     // expect(cvToString(poxAddrInfo1CV.value.data["total-ustx"])).toBe("u90000000011000");
-    expect((poxAddrInfo2CV.value.data["total-ustx"] as UIntCV).value).toBe(
+    expect((poxAddrInfo2["total-ustx"] as UIntCV).value).toBe(
       BigInt(1080_000_000_011_111)
     );
 

--- a/tests/integration/pox/stacking/direct-stacking-with-bug.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-with-bug.spec.ts
@@ -1,6 +1,6 @@
 import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
-import { ClarityValue, UIntCV, uintCV } from "@stacks/transactions";
+import { ClarityValue, uintCV } from "@stacks/transactions";
 import { Accounts } from "../../constants";
 import {
   buildDevnetNetworkOrchestrator,
@@ -134,9 +134,7 @@ describe("testing solo stacker increase without bug", () => {
       2,
       Accounts.FAUCET.stxAddress
     )) as Record<string, ClarityValue>;
-    expect((poxAddrInfo0["total-ustx"] as UIntCV).value).toEqual(
-      uintCV(900_000_000_000_001)
-    );
+    expect(poxAddrInfo0["total-ustx"]).toEqual(uintCV(900_000_000_000_001));
 
     // Check Bob's table entry
     const poxAddrInfo1 = (await readRewardCyclePoxAddressForAddress(
@@ -145,12 +143,10 @@ describe("testing solo stacker increase without bug", () => {
       Accounts.WALLET_2.stxAddress
     )) as Record<string, ClarityValue>;
     // HERE'S THE BUG: THIS SHOULD BE `u90000000000110`
-    // expect((poxAddrInfo1["total-ustx"] as UIntCV).value).toEqual(
+    // expect(poxAddrInfo1["total-ustx"]).toEqual(
     //   uintCV(90_000_000_000_110)
     // );
-    expect((poxAddrInfo1["total-ustx"] as UIntCV).value).toEqual(
-      uintCV(900_000_000_000_111)
-    );
+    expect(poxAddrInfo1["total-ustx"]).toEqual(uintCV(990_000_000_000_111));
 
     // Check Cloe's table entry
     const poxAddrInfo2 = (await readRewardCyclePoxAddressForAddress(
@@ -159,10 +155,8 @@ describe("testing solo stacker increase without bug", () => {
       Accounts.WALLET_3.stxAddress
     )) as Record<string, ClarityValue>;
     // HERE'S THE BUG: THIS SHOULD BE `u90000000011000`
-    // expect(cvToString(poxAddrInfo1CV.value.data["total-ustx"])).toBe("u90000000011000");
-    expect((poxAddrInfo2["total-ustx"] as UIntCV).value).toBe(
-      BigInt(1080_000_000_011_111)
-    );
+    // expect(poxAddrInfo2["total-ustx"]).toEqual(uintCV(90_000_000_011_000));
+    expect(poxAddrInfo2["total-ustx"]).toEqual(uintCV(1080_000_000_011_111));
 
     // advance to block 120, the last one before chain halt
     let coreInfo = await getCoreInfo(network);

--- a/tests/integration/pox/stacking/direct-stacking.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking.spec.ts
@@ -15,7 +15,7 @@ import {
   broadcastStackIncrease,
   broadcastStackSTX,
 } from "../helpers-direct-stacking";
-import { ClarityValue, UIntCV } from "@stacks/transactions";
+import { ClarityValue, uintCV } from "@stacks/transactions";
 
 describe("testing stacking under epoch 2.1", () => {
   let orchestrator: DevnetNetworkOrchestrator;
@@ -107,20 +107,16 @@ describe("testing stacking under epoch 2.1", () => {
       Accounts.WALLET_2.stxAddress
     )) as Record<string, ClarityValue>;
     // HERE'S THE BUG: THIS SHOULD BE `u80000000000000`
-    // expect((poxAddrInfo0["total-ustx"] as UIntCV).value).toBe(
-    //   BigInt(80_000_000_000_000)
+    // expect(poxAddrInfo0["total-ustx"]).toEqual(
+    //   uintCV(80_000_000_000_000)
     // );
-    expect((poxAddrInfo0["total-ustx"] as UIntCV).value).toBe(
-      BigInt(100_000_000_000_000)
-    );
+    expect(poxAddrInfo0["total-ustx"]).toEqual(uintCV(100_000_000_000_000));
 
     const poxAddrInfo1 = (await readRewardCyclePoxAddressForAddress(
       network,
       2,
       Accounts.WALLET_1.stxAddress
     )) as Record<string, ClarityValue>;
-    expect((poxAddrInfo1["total-ustx"] as UIntCV).value).toBe(
-      BigInt(50_000_000_000_000)
-    );
+    expect(poxAddrInfo1["total-ustx"]).toEqual(uintCV(50_000_000_000_000));
   });
 });

--- a/tests/integration/pox/stacking/direct-stacking.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking.spec.ts
@@ -85,9 +85,7 @@ describe("testing stacking under epoch 2.1", () => {
 
     // Asserts about pox info for better knowledge sharing
     expect(poxInfo.contract_id).toBe("ST000000000000000000002AMW42H.pox-2");
-    expect(poxInfo.pox_activation_threshold_ustx).toBe(50_286_942_145_278);
     expect(poxInfo.current_cycle.id).toBe(1);
-    expect(poxInfo.current_cycle.min_threshold_ustx).toBe(20_960_000_000_000);
 
     // Assert that the next cycle has 100m STX locked
     expect(poxInfo.current_cycle.stacked_ustx).toBe(0);


### PR DESCRIPTION
* `readRewardCyclePoxAddressList`: returns the whole list
* `readRewardCyclePoxAddressForAddress`: returns one entry matching the
  specified Stacks address
* `readRewardCyclePoxAddressListAtIndex`: returns one entry from the
  specified index