### PR TITLE
fix: make version checking work everywhere

### DIFF
--- a/tests/integration/clarity/traits/use-and-define.spec.ts
+++ b/tests/integration/clarity/traits/use-and-define.spec.ts
@@ -4,22 +4,18 @@ import {
   AnchorMode,
   PostConditionMode,
   TxBroadcastResultOk,
-  makeContractCall,
-  SignedContractCallOptions,
 } from "@stacks/transactions";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
-import { Accounts, Constants } from "../../constants";
+import { Accounts } from "../../constants";
 import {
   buildDevnetNetworkOrchestrator,
   getBitcoinBlockHeight,
   getNetworkIdFromEnv,
-  getChainInfo,
   DEFAULT_EPOCH_TIMELINE,
 } from "../../helpers";
 import {
   DevnetNetworkOrchestrator,
   StacksTransactionMetadata,
-  stacksNodeVersion,
 } from "@hirosystems/stacks-devnet-js";
 
 describe("use and define trait with same name", () => {

--- a/tests/integration/epoch-2-2/wrap-trait-workaround.spec.ts
+++ b/tests/integration/epoch-2-2/wrap-trait-workaround.spec.ts
@@ -1,7 +1,6 @@
 import {
   DevnetNetworkOrchestrator,
   StacksTransactionMetadata,
-  stacksNodeVersion,
 } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
 import {

--- a/tests/integration/epoch-2-2/wrap-trait-workaround2.spec.ts
+++ b/tests/integration/epoch-2-2/wrap-trait-workaround2.spec.ts
@@ -1,8 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  StacksTransactionMetadata,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
 import {
   AnchorMode,
@@ -19,7 +15,6 @@ import {
   buildDevnetNetworkOrchestrator,
   deployContract,
   getNetworkIdFromEnv,
-  waitForStacksTransaction,
 } from "../helpers";
 
 describe("trait parameter with wrapped implementation in Stacks 2.2", () => {

--- a/tests/integration/epoch-2-2/wrap-trait-workaround3.spec.ts
+++ b/tests/integration/epoch-2-2/wrap-trait-workaround3.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
 import {
   AnchorMode,

--- a/tests/integration/helpers.ts
+++ b/tests/integration/helpers.ts
@@ -4,7 +4,6 @@ import {
   StacksChainUpdate,
   StacksTransactionMetadata,
   getIsolatedNetworkConfigUsingNetworkId,
-  stacksNodeVersion,
 } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork } from "@stacks/network";
 import { Constants, DEFAULT_FEE } from "./constants";
@@ -155,13 +154,15 @@ export const getNetworkIdFromEnv = (): number => {
 };
 
 export const getStacksNodeVersion = () => {
-  let version: string;
-  if (typeof stacksNodeVersion === "function") {
-    version = stacksNodeVersion();
-  } else {
-    version = "2.1";
+  let nodeVersion: string | undefined;
+  // Try to import the stacksNodeVersion export
+  try {
+    const { stacksNodeVersion } = require("@hirosystems/stacks-devnet-js");
+    nodeVersion = stacksNodeVersion();
+  } catch (e) {
+    nodeVersion = "2.1";
   }
-  return version;
+  return nodeVersion;
 };
 
 const delay = () => new Promise((resolve) => setTimeout(resolve, 2000));

--- a/tests/integration/pox/stacking/direct-and-pooled-extend-bug.spec.ts
+++ b/tests/integration/pox/stacking/direct-and-pooled-extend-bug.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
 import { SomeCV, cvToString, uintCV } from "@stacks/transactions";
 import { Accounts, Constants } from "../../constants";
@@ -11,6 +8,7 @@ import {
   broadcastSTXTransfer,
   buildDevnetNetworkOrchestrator,
   getNetworkIdFromEnv,
+  getStacksNodeVersion,
   waitForStacksTransaction,
 } from "../../helpers";
 import {
@@ -28,12 +26,7 @@ import {
 
 describe("testing mixed direct and pooled stacking with extend under epoch 2.1", () => {
   let orchestrator: DevnetNetworkOrchestrator;
-  let version: string;
-  if (typeof stacksNodeVersion === "function") {
-    version = stacksNodeVersion();
-  } else {
-    version = "2.1";
-  }
+  const version = getStacksNodeVersion();
   const fee = 1000;
   const timeline = {
     ...DEFAULT_EPOCH_TIMELINE,

--- a/tests/integration/pox/stacking/direct-and-pooled-extend-bug.spec.ts
+++ b/tests/integration/pox/stacking/direct-and-pooled-extend-bug.spec.ts
@@ -29,7 +29,6 @@ describe("testing mixed direct and pooled stacking with extend under epoch 2.1",
   const version = getStacksNodeVersion();
   const fee = 1000;
   const timeline = {
-    ...DEFAULT_EPOCH_TIMELINE,
     epoch_2_2: 138,
     epoch_2_3: 142,
     epoch_2_4: 146,
@@ -310,7 +309,7 @@ describe("testing mixed direct and pooled stacking with extend under epoch 2.1",
 
   it("everything unlocks as expected upon v2 unlock height", async () => {
     // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
+    if (Number(version) < 2.2) {
       return;
     }
     const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
@@ -357,21 +356,20 @@ describe("testing mixed direct and pooled stacking with extend under epoch 2.1",
     await asyncExpectStacksTransactionSuccess(orchestrator, response.txid);
   });
 
-  it("PoX should stay disabled indefinitely", async () => {
-    // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
-      return;
+  it("PoX should stay disabled indefinitely in 2.2 and 2.3", async () => {
+    if (version === "2.2" || version === "2.3") {
+      const network = new StacksTestnet({
+        url: orchestrator.getStacksNodeUrl(),
+      });
+      let poxInfo = await getPoxInfo(network);
+      await waitForNextRewardPhase(
+        network,
+        orchestrator,
+        poxInfo.current_cycle.id + 1
+      );
+
+      poxInfo = await getPoxInfo(network);
+      expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
     }
-
-    const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
-    let poxInfo = await getPoxInfo(network);
-    await waitForNextRewardPhase(
-      network,
-      orchestrator,
-      poxInfo.current_cycle.id + 1
-    );
-
-    poxInfo = await getPoxInfo(network);
-    expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
   });
 });

--- a/tests/integration/pox/stacking/direct-and-pooled-increase-as-pool-operator.spec.ts
+++ b/tests/integration/pox/stacking/direct-and-pooled-increase-as-pool-operator.spec.ts
@@ -29,7 +29,6 @@ describe("testing direct stacker as pool operator without auto-unlock under epoc
   const version = getStacksNodeVersion();
   const fee = 1000;
   const timeline = {
-    ...DEFAULT_EPOCH_TIMELINE,
     epoch_2_2: 127,
     epoch_2_3: 132,
     epoch_2_4: 134,
@@ -187,7 +186,7 @@ describe("testing direct stacker as pool operator without auto-unlock under epoc
 
   it("everything unlocks as expected upon v2 unlock height", async () => {
     // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
+    if (Number(version) < 2.2) {
       return;
     }
     const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
@@ -234,21 +233,20 @@ describe("testing direct stacker as pool operator without auto-unlock under epoc
     await asyncExpectStacksTransactionSuccess(orchestrator, response.txid);
   });
 
-  it("PoX should stay disabled indefinitely", async () => {
-    // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
-      return;
+  it("PoX should stay disabled indefinitely in 2.2 and 2.3", async () => {
+    if (version === "2.2" || version === "2.3") {
+      const network = new StacksTestnet({
+        url: orchestrator.getStacksNodeUrl(),
+      });
+      let poxInfo = await getPoxInfo(network);
+      await waitForNextRewardPhase(
+        network,
+        orchestrator,
+        poxInfo.current_cycle.id + 1
+      );
+
+      poxInfo = await getPoxInfo(network);
+      expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
     }
-
-    const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
-    let poxInfo = await getPoxInfo(network);
-    await waitForNextRewardPhase(
-      network,
-      orchestrator,
-      poxInfo.current_cycle.id + 1
-    );
-
-    poxInfo = await getPoxInfo(network);
-    expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
   });
 });

--- a/tests/integration/pox/stacking/direct-and-pooled-increase-as-pool-operator.spec.ts
+++ b/tests/integration/pox/stacking/direct-and-pooled-increase-as-pool-operator.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
 import { uintCV } from "@stacks/transactions";
 import { Accounts, Constants } from "../../constants";
@@ -11,6 +8,7 @@ import {
   broadcastSTXTransfer,
   buildDevnetNetworkOrchestrator,
   getNetworkIdFromEnv,
+  getStacksNodeVersion,
   waitForStacksTransaction,
 } from "../../helpers";
 import {
@@ -28,12 +26,7 @@ import {
 
 describe("testing direct stacker as pool operator without auto-unlock under epoch 2.1", () => {
   let orchestrator: DevnetNetworkOrchestrator;
-  let version: string;
-  if (typeof stacksNodeVersion === "function") {
-    version = stacksNodeVersion();
-  } else {
-    version = "2.1";
-  }
+  const version = getStacksNodeVersion();
   const fee = 1000;
   const timeline = {
     ...DEFAULT_EPOCH_TIMELINE,

--- a/tests/integration/pox/stacking/direct-and-pooled-increase-bad-pool-operator.spec.ts
+++ b/tests/integration/pox/stacking/direct-and-pooled-increase-bad-pool-operator.spec.ts
@@ -106,7 +106,7 @@ describe("testing stacker who is a bad pool operator under epoch 2.1", () => {
 
   it("everything unlocks as expected upon v2 unlock height", async () => {
     // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
+    if (Number(version) < 2.2) {
       return;
     }
     const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
@@ -155,19 +155,19 @@ describe("testing stacker who is a bad pool operator under epoch 2.1", () => {
 
   it("PoX should stay disabled indefinitely", async () => {
     // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
-      return;
+    if (version === "2.2" || version === "2.3") {
+      const network = new StacksTestnet({
+        url: orchestrator.getStacksNodeUrl(),
+      });
+      let poxInfo = await getPoxInfo(network);
+      await waitForNextRewardPhase(
+        network,
+        orchestrator,
+        poxInfo.current_cycle.id + 1
+      );
+
+      poxInfo = await getPoxInfo(network);
+      expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
     }
-
-    const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
-    let poxInfo = await getPoxInfo(network);
-    await waitForNextRewardPhase(
-      network,
-      orchestrator,
-      poxInfo.current_cycle.id + 1
-    );
-
-    poxInfo = await getPoxInfo(network);
-    expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
   });
 });

--- a/tests/integration/pox/stacking/direct-and-pooled-increase-bad-pool-operator.spec.ts
+++ b/tests/integration/pox/stacking/direct-and-pooled-increase-bad-pool-operator.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
 import { Accounts, Constants } from "../../constants";
 import {
@@ -9,6 +6,7 @@ import {
   broadcastSTXTransfer,
   buildDevnetNetworkOrchestrator,
   getNetworkIdFromEnv,
+  getStacksNodeVersion,
   waitForStacksTransaction,
 } from "../../helpers";
 import {
@@ -24,12 +22,7 @@ import {
 
 describe("testing stacker who is a bad pool operator under epoch 2.1", () => {
   let orchestrator: DevnetNetworkOrchestrator;
-  let version: string;
-  if (typeof stacksNodeVersion === "function") {
-    version = stacksNodeVersion();
-  } else {
-    version = "2.1";
-  }
+  const version = getStacksNodeVersion();
   const fee = 1000;
   let aliceNonce = 0;
   let bobNonce = 0;

--- a/tests/integration/pox/stacking/direct-and-pooled-increase-bug.spec.ts
+++ b/tests/integration/pox/stacking/direct-and-pooled-increase-bug.spec.ts
@@ -28,7 +28,6 @@ describe("testing mixed direct and pooled stacking under epoch 2.1", () => {
   let orchestrator: DevnetNetworkOrchestrator;
   const version = getStacksNodeVersion();
   const timeline = {
-    ...DEFAULT_EPOCH_TIMELINE,
     epoch_2_2: 126,
     epoch_2_3: 131,
     epoch_2_4: 133,
@@ -195,7 +194,7 @@ describe("testing mixed direct and pooled stacking under epoch 2.1", () => {
 
   it("everything unlocks as expected upon v2 unlock height", async () => {
     // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
+    if (Number(version) < 2.2) {
       return;
     }
     const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
@@ -242,21 +241,20 @@ describe("testing mixed direct and pooled stacking under epoch 2.1", () => {
     await asyncExpectStacksTransactionSuccess(orchestrator, response.txid);
   });
 
-  it("PoX should stay disabled indefinitely", async () => {
-    // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
-      return;
+  it("PoX should stay disabled indefinitely in 2.2 and 2.3", async () => {
+    if (version === "2.2" || version === "2.3") {
+      const network = new StacksTestnet({
+        url: orchestrator.getStacksNodeUrl(),
+      });
+      let poxInfo = await getPoxInfo(network);
+      await waitForNextRewardPhase(
+        network,
+        orchestrator,
+        poxInfo.current_cycle.id + 1
+      );
+
+      poxInfo = await getPoxInfo(network);
+      expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
     }
-
-    const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
-    let poxInfo = await getPoxInfo(network);
-    await waitForNextRewardPhase(
-      network,
-      orchestrator,
-      poxInfo.current_cycle.id + 1
-    );
-
-    poxInfo = await getPoxInfo(network);
-    expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
   });
 });

--- a/tests/integration/pox/stacking/direct-and-pooled-increase-bug.spec.ts
+++ b/tests/integration/pox/stacking/direct-and-pooled-increase-bug.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
 import { uintCV } from "@stacks/transactions";
 import { Accounts, Constants } from "../../constants";
@@ -11,6 +8,7 @@ import {
   broadcastSTXTransfer,
   buildDevnetNetworkOrchestrator,
   getNetworkIdFromEnv,
+  getStacksNodeVersion,
   waitForStacksTransaction,
 } from "../../helpers";
 import {
@@ -28,12 +26,7 @@ import {
 
 describe("testing mixed direct and pooled stacking under epoch 2.1", () => {
   let orchestrator: DevnetNetworkOrchestrator;
-  let version: string;
-  if (typeof stacksNodeVersion === "function") {
-    version = stacksNodeVersion();
-  } else {
-    version = "2.1";
-  }
+  const version = getStacksNodeVersion();
   const timeline = {
     ...DEFAULT_EPOCH_TIMELINE,
     epoch_2_2: 126,

--- a/tests/integration/pox/stacking/direct-stacking-auto-unlock.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-auto-unlock.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
 import { uintCV } from "@stacks/transactions";
 import { Accounts, Constants } from "../../constants";
@@ -11,6 +8,7 @@ import {
   broadcastSTXTransfer,
   buildDevnetNetworkOrchestrator,
   getNetworkIdFromEnv,
+  getStacksNodeVersion,
   waitForStacksTransaction,
 } from "../../helpers";
 import {
@@ -23,12 +21,7 @@ import { broadcastStackSTX } from "../helpers-direct-stacking";
 
 describe("testing solo stacker below minimum", () => {
   let orchestrator: DevnetNetworkOrchestrator;
-  let version: string;
-  if (typeof stacksNodeVersion === "function") {
-    version = stacksNodeVersion();
-  } else {
-    version = "2.1";
-  }
+  const version = getStacksNodeVersion();
   const timeline = {
     ...DEFAULT_EPOCH_TIMELINE,
     epoch_2_2: 127,

--- a/tests/integration/pox/stacking/direct-stacking-auto-unlock.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-auto-unlock.spec.ts
@@ -23,7 +23,6 @@ describe("testing solo stacker below minimum", () => {
   let orchestrator: DevnetNetworkOrchestrator;
   const version = getStacksNodeVersion();
   const timeline = {
-    ...DEFAULT_EPOCH_TIMELINE,
     epoch_2_2: 127,
     epoch_2_3: 131,
     epoch_2_4: 133,
@@ -157,7 +156,7 @@ describe("testing solo stacker below minimum", () => {
 
   it("everything unlocks as expected upon v2 unlock height", async () => {
     // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
+    if (Number(version) < 2.2) {
       return;
     }
     const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
@@ -204,21 +203,20 @@ describe("testing solo stacker below minimum", () => {
     await asyncExpectStacksTransactionSuccess(orchestrator, response.txid);
   });
 
-  it("PoX should stay disabled indefinitely", async () => {
-    // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
-      return;
+  it("PoX should stay disabled indefinitely in 2.2 and 2.3", async () => {
+    if (version === "2.2" || version === "2.3") {
+      const network = new StacksTestnet({
+        url: orchestrator.getStacksNodeUrl(),
+      });
+      let poxInfo = await getPoxInfo(network);
+      await waitForNextRewardPhase(
+        network,
+        orchestrator,
+        poxInfo.current_cycle.id + 1
+      );
+
+      poxInfo = await getPoxInfo(network);
+      expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
     }
-
-    const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
-    let poxInfo = await getPoxInfo(network);
-    await waitForNextRewardPhase(
-      network,
-      orchestrator,
-      poxInfo.current_cycle.id + 1
-    );
-
-    poxInfo = await getPoxInfo(network);
-    expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
   });
 });

--- a/tests/integration/pox/stacking/direct-stacking-extend.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-extend.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
 import { ClarityValue, uintCV } from "@stacks/transactions";
 import { Accounts, Constants } from "../../constants";
@@ -11,6 +8,7 @@ import {
   broadcastSTXTransfer,
   buildDevnetNetworkOrchestrator,
   getNetworkIdFromEnv,
+  getStacksNodeVersion,
   waitForStacksTransaction,
 } from "../../helpers";
 import {
@@ -26,12 +24,7 @@ import {
 
 describe("testing stack-extend functionality", () => {
   let orchestrator: DevnetNetworkOrchestrator;
-  let version: string;
-  if (typeof stacksNodeVersion === "function") {
-    version = stacksNodeVersion();
-  } else {
-    version = "2.1";
-  }
+  const version = getStacksNodeVersion();
   const timeline = {
     ...DEFAULT_EPOCH_TIMELINE,
     epoch_2_2: 143,

--- a/tests/integration/pox/stacking/direct-stacking-extend.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-extend.spec.ts
@@ -26,7 +26,6 @@ describe("testing stack-extend functionality", () => {
   let orchestrator: DevnetNetworkOrchestrator;
   const version = getStacksNodeVersion();
   const timeline = {
-    ...DEFAULT_EPOCH_TIMELINE,
     epoch_2_2: 143,
     epoch_2_3: 145,
     epoch_2_4: 147,
@@ -116,7 +115,7 @@ describe("testing stack-extend functionality", () => {
 
   it("everything unlocks as expected upon v2 unlock height", async () => {
     // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
+    if (Number(version) < 2.2) {
       return;
     }
     const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
@@ -145,21 +144,20 @@ describe("testing stack-extend functionality", () => {
     await asyncExpectStacksTransactionSuccess(orchestrator, response.txid);
   });
 
-  it("PoX should stay disabled indefinitely", async () => {
-    // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
-      return;
+  it("PoX should stay disabled indefinitely in 2.2 and 2.3", async () => {
+    if (version === "2.2" || version === "2.3") {
+      const network = new StacksTestnet({
+        url: orchestrator.getStacksNodeUrl(),
+      });
+      let poxInfo = await getPoxInfo(network);
+      await waitForNextRewardPhase(
+        network,
+        orchestrator,
+        poxInfo.current_cycle.id + 1
+      );
+
+      poxInfo = await getPoxInfo(network);
+      expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
     }
-
-    const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
-    let poxInfo = await getPoxInfo(network);
-    await waitForNextRewardPhase(
-      network,
-      orchestrator,
-      poxInfo.current_cycle.id + 1
-    );
-
-    poxInfo = await getPoxInfo(network);
-    expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
   });
 });

--- a/tests/integration/pox/stacking/direct-stacking-good-order.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-good-order.spec.ts
@@ -124,7 +124,7 @@ describe("testing solo stacker increase without bug", () => {
 
   it("everything unlocks as expected upon v2 unlock height", async () => {
     // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
+    if (Number(version) < 2.2) {
       return;
     }
     const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
@@ -171,21 +171,20 @@ describe("testing solo stacker increase without bug", () => {
     await asyncExpectStacksTransactionSuccess(orchestrator, response.txid);
   });
 
-  it("PoX should stay disabled indefinitely", async () => {
-    // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
-      return;
+  it("PoX should stay disabled indefinitely in 2.2 and 2.3", async () => {
+    if (version === "2.2" || version === "2.3") {
+      const network = new StacksTestnet({
+        url: orchestrator.getStacksNodeUrl(),
+      });
+      let poxInfo = await getPoxInfo(network);
+      await waitForNextRewardPhase(
+        network,
+        orchestrator,
+        poxInfo.current_cycle.id + 1
+      );
+
+      poxInfo = await getPoxInfo(network);
+      expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
     }
-
-    const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
-    let poxInfo = await getPoxInfo(network);
-    await waitForNextRewardPhase(
-      network,
-      orchestrator,
-      poxInfo.current_cycle.id + 1
-    );
-
-    poxInfo = await getPoxInfo(network);
-    expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
   });
 });

--- a/tests/integration/pox/stacking/direct-stacking-good-order.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-good-order.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
 import { ClarityValue, cvToString, uintCV } from "@stacks/transactions";
 import { Accounts, Constants } from "../../constants";
@@ -10,6 +7,7 @@ import {
   broadcastSTXTransfer,
   buildDevnetNetworkOrchestrator,
   getNetworkIdFromEnv,
+  getStacksNodeVersion,
   waitForStacksTransaction,
 } from "../../helpers";
 import {
@@ -25,12 +23,7 @@ import {
 
 describe("testing solo stacker increase without bug", () => {
   let orchestrator: DevnetNetworkOrchestrator;
-  let version: string;
-  if (typeof stacksNodeVersion === "function") {
-    version = stacksNodeVersion();
-  } else {
-    version = "2.1";
-  }
+  const version = getStacksNodeVersion();
   const fee = 1000;
   let aliceNonce = 0;
   let bobNonce = 0;

--- a/tests/integration/pox/stacking/direct-stacking-increase-twice.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-increase-twice.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
 import { Accounts, Constants } from "../../constants";
 import {
@@ -9,6 +6,7 @@ import {
   broadcastSTXTransfer,
   buildDevnetNetworkOrchestrator,
   getNetworkIdFromEnv,
+  getStacksNodeVersion,
   waitForStacksTransaction,
 } from "../../helpers";
 import {
@@ -23,12 +21,7 @@ import {
 
 describe("testing solo stacker increase without bug", () => {
   let orchestrator: DevnetNetworkOrchestrator;
-  let version: string;
-  if (typeof stacksNodeVersion === "function") {
-    version = stacksNodeVersion();
-  } else {
-    version = "2.1";
-  }
+  const version = getStacksNodeVersion();
   const fee = 1000;
   let bobNonce = 0;
 

--- a/tests/integration/pox/stacking/direct-stacking-increase-twice.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-increase-twice.spec.ts
@@ -101,7 +101,7 @@ describe("testing solo stacker increase without bug", () => {
 
   it("everything unlocks as expected upon v2 unlock height", async () => {
     // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
+    if (Number(version) < 2.2) {
       return;
     }
     const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
@@ -130,21 +130,20 @@ describe("testing solo stacker increase without bug", () => {
     await asyncExpectStacksTransactionSuccess(orchestrator, response.txid);
   });
 
-  it("PoX should stay disabled indefinitely", async () => {
-    // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
-      return;
+  it("PoX should stay disabled indefinitely in 2.2 and 2.3", async () => {
+    if (version === "2.2" || version === "2.3") {
+      const network = new StacksTestnet({
+        url: orchestrator.getStacksNodeUrl(),
+      });
+      let poxInfo = await getPoxInfo(network);
+      await waitForNextRewardPhase(
+        network,
+        orchestrator,
+        poxInfo.current_cycle.id + 1
+      );
+
+      poxInfo = await getPoxInfo(network);
+      expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
     }
-
-    const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
-    let poxInfo = await getPoxInfo(network);
-    await waitForNextRewardPhase(
-      network,
-      orchestrator,
-      poxInfo.current_cycle.id + 1
-    );
-
-    poxInfo = await getPoxInfo(network);
-    expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
   });
 });

--- a/tests/integration/pox/stacking/direct-stacking-many-increase.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-many-increase.spec.ts
@@ -156,7 +156,7 @@ describe("testing multiple stack-stx and stack-increase calls in the same block"
 
   it("everything unlocks as expected upon v2 unlock height", async () => {
     // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
+    if (Number(version) < 2.2) {
       return;
     }
     const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
@@ -203,21 +203,20 @@ describe("testing multiple stack-stx and stack-increase calls in the same block"
     await asyncExpectStacksTransactionSuccess(orchestrator, response.txid);
   });
 
-  it("PoX should stay disabled indefinitely", async () => {
-    // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
-      return;
+  it("PoX should stay disabled indefinitely in 2.2 and 2.3", async () => {
+    if (version === "2.2" || version === "2.3") {
+      const network = new StacksTestnet({
+        url: orchestrator.getStacksNodeUrl(),
+      });
+      let poxInfo = await getPoxInfo(network);
+      await waitForNextRewardPhase(
+        network,
+        orchestrator,
+        poxInfo.current_cycle.id + 1
+      );
+
+      poxInfo = await getPoxInfo(network);
+      expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
     }
-
-    const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
-    let poxInfo = await getPoxInfo(network);
-    await waitForNextRewardPhase(
-      network,
-      orchestrator,
-      poxInfo.current_cycle.id + 1
-    );
-
-    poxInfo = await getPoxInfo(network);
-    expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
   });
 });

--- a/tests/integration/pox/stacking/direct-stacking-many-increase.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-many-increase.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
 import { cvToString } from "@stacks/transactions";
 import { Accounts, Constants } from "../../constants";
@@ -10,6 +7,7 @@ import {
   broadcastSTXTransfer,
   buildDevnetNetworkOrchestrator,
   getNetworkIdFromEnv,
+  getStacksNodeVersion,
   waitForStacksTransaction,
 } from "../../helpers";
 import {
@@ -25,12 +23,7 @@ import {
 
 describe("testing multiple stack-stx and stack-increase calls in the same block", () => {
   let orchestrator: DevnetNetworkOrchestrator;
-  let version: string;
-  if (typeof stacksNodeVersion === "function") {
-    version = stacksNodeVersion();
-  } else {
-    version = "2.1";
-  }
+  const version = getStacksNodeVersion();
   const fee = 1000;
   let aliceNonce = 0;
   let bobNonce = 0;

--- a/tests/integration/pox/stacking/direct-stacking-with-bug.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-with-bug.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
 import { uintCV } from "@stacks/transactions";
 import { Accounts, Constants } from "../../constants";
@@ -9,6 +6,7 @@ import {
   DEFAULT_EPOCH_TIMELINE,
   buildDevnetNetworkOrchestrator,
   getNetworkIdFromEnv,
+  getStacksNodeVersion,
   waitForStacksTransaction,
 } from "../../helpers";
 import {
@@ -25,12 +23,7 @@ import {
 
 describe("testing solo stacker increase with bug", () => {
   let orchestrator: DevnetNetworkOrchestrator;
-  let version: string;
-  if (typeof stacksNodeVersion === "function") {
-    version = stacksNodeVersion();
-  } else {
-    version = "2.1";
-  }
+  const version = getStacksNodeVersion();
 
   beforeAll(() => {
     const timeline = {

--- a/tests/integration/pox/stacking/direct-stacking-with-bug.spec.ts
+++ b/tests/integration/pox/stacking/direct-stacking-with-bug.spec.ts
@@ -27,7 +27,6 @@ describe("testing solo stacker increase with bug", () => {
 
   beforeAll(() => {
     const timeline = {
-      ...DEFAULT_EPOCH_TIMELINE,
       epoch_2_2: 118,
     };
     orchestrator = buildDevnetNetworkOrchestrator(

--- a/tests/integration/pox/stacking/epoch-gating-bug.spec.ts
+++ b/tests/integration/pox/stacking/epoch-gating-bug.spec.ts
@@ -26,7 +26,6 @@ import {
 describe("testing solo stacker increase with bug", () => {
   let orchestrator: DevnetNetworkOrchestrator;
   const timeline = {
-    ...DEFAULT_EPOCH_TIMELINE,
     epoch_2_2: 118,
   };
 
@@ -46,7 +45,7 @@ describe("testing solo stacker increase with bug", () => {
     const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
 
     await orchestrator.waitForStacksBlockAnchoredOnBitcoinBlockOfHeight(
-      timeline.pox_2_activation + 1
+      Constants.DEVNET_DEFAULT_POX_2_ACTIVATION + 1
     );
 
     const codeBody = `(define-read-only (check-unlock-height (address principal))

--- a/tests/integration/pox/stacking/epoch-gating-bug.spec.ts
+++ b/tests/integration/pox/stacking/epoch-gating-bug.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
 import {
   AnchorMode,

--- a/tests/integration/pox/stacking/epoch_2_0.spec.ts
+++ b/tests/integration/pox/stacking/epoch_2_0.spec.ts
@@ -1,9 +1,6 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
-import { Accounts, Constants } from "../../constants";
+import { Accounts } from "../../constants";
 import {
   DEFAULT_EPOCH_TIMELINE,
   buildDevnetNetworkOrchestrator,

--- a/tests/integration/pox/stacking/epoch_2_0.spec.ts
+++ b/tests/integration/pox/stacking/epoch_2_0.spec.ts
@@ -13,12 +13,9 @@ import { broadcastStackSTX } from "../helpers-direct-stacking";
 describe("testing stacking under epoch 2.0", () => {
   let orchestrator: DevnetNetworkOrchestrator;
   const timeline = {
-    ...DEFAULT_EPOCH_TIMELINE,
     epoch_2_1: 126,
     pox_2_activation: 130,
     epoch_2_2: 2000,
-    epoch_2_3: 2001,
-    epoch_2_4: 2002,
   };
 
   beforeAll(() => {

--- a/tests/integration/pox/stacking/epoch_2_1.spec.ts
+++ b/tests/integration/pox/stacking/epoch_2_1.spec.ts
@@ -14,10 +14,7 @@ describe("testing stacking under epoch 2.1", () => {
 
   beforeAll(() => {
     const timeline = {
-      ...DEFAULT_EPOCH_TIMELINE,
       epoch_2_2: 2000,
-      epoch_2_3: 2001,
-      epoch_2_4: 2002,
     };
     orchestrator = buildDevnetNetworkOrchestrator(
       getNetworkIdFromEnv(),

--- a/tests/integration/pox/stacking/epoch_2_1.spec.ts
+++ b/tests/integration/pox/stacking/epoch_2_1.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
 import { Accounts, Constants } from "../../constants";
 import {

--- a/tests/integration/pox/stacking/network.spec.ts
+++ b/tests/integration/pox/stacking/network.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
 import {
   DEFAULT_EPOCH_TIMELINE,

--- a/tests/integration/pox/stacking/pooled-stacking-switch-pools.spec.ts
+++ b/tests/integration/pox/stacking/pooled-stacking-switch-pools.spec.ts
@@ -10,13 +10,11 @@ import {
   asyncExpectStacksTransactionSuccess,
   buildDevnetNetworkOrchestrator,
   getNetworkIdFromEnv,
-  getStacksNodeVersion,
 } from "../../helpers";
 import {
   getPoxInfo,
   readRewardCyclePoxAddressForAddress,
   readRewardCyclePoxAddressListAtIndex,
-  waitForNextPreparePhase,
   waitForNextRewardPhase,
 } from "../helpers";
 import {
@@ -32,7 +30,6 @@ describe("testing pooled stacking under epoch 2.1", () => {
   let orchestrator: DevnetNetworkOrchestrator;
 
   const timeline = {
-    ...DEFAULT_EPOCH_TIMELINE,
     epoch_2_2: 128,
     pox_2_unlock_height: 129,
     epoch_2_3: 138,
@@ -55,7 +52,7 @@ describe("testing pooled stacking under epoch 2.1", () => {
 
     // Wait for the pox-2 activation
     await orchestrator.waitForStacksBlockAnchoredOnBitcoinBlockOfHeight(
-      timeline.pox_2_activation
+      Constants.DEVNET_DEFAULT_POX_2_ACTIVATION
     );
 
     // Alice delegates 95m STX to Cloe

--- a/tests/integration/pox/stacking/pooled-stacking.spec.ts
+++ b/tests/integration/pox/stacking/pooled-stacking.spec.ts
@@ -34,7 +34,6 @@ describe("testing pooled stacking under epoch 2.1", () => {
   const version = getStacksNodeVersion();
   const fee = 1000;
   const timeline = {
-    ...DEFAULT_EPOCH_TIMELINE,
     epoch_2_2: 144,
     epoch_2_3: 147,
     epoch_2_4: 149,
@@ -413,7 +412,7 @@ describe("testing pooled stacking under epoch 2.1", () => {
 
   it("everything unlocks as expected upon v2 unlock height", async () => {
     // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
+    if (Number(version) < 2.2) {
       return;
     }
     const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
@@ -460,21 +459,20 @@ describe("testing pooled stacking under epoch 2.1", () => {
     await asyncExpectStacksTransactionSuccess(orchestrator, response.txid);
   });
 
-  it("PoX should stay disabled indefinitely", async () => {
-    // This test should only run when running a 2.2 node
-    if (version !== "2.2") {
-      return;
+  it("PoX should stay disabled indefinitely in 2.2 and 2.3", async () => {
+    if (version === "2.2" || version === "2.3") {
+      const network = new StacksTestnet({
+        url: orchestrator.getStacksNodeUrl(),
+      });
+      let poxInfo = await getPoxInfo(network);
+      await waitForNextRewardPhase(
+        network,
+        orchestrator,
+        poxInfo.current_cycle.id + 1
+      );
+
+      poxInfo = await getPoxInfo(network);
+      expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
     }
-
-    const network = new StacksTestnet({ url: orchestrator.getStacksNodeUrl() });
-    let poxInfo = await getPoxInfo(network);
-    await waitForNextRewardPhase(
-      network,
-      orchestrator,
-      poxInfo.current_cycle.id + 1
-    );
-
-    poxInfo = await getPoxInfo(network);
-    expect(poxInfo.current_cycle.is_pox_active).toBeFalsy();
   });
 });

--- a/tests/integration/pox/stacking/pooled-stacking.spec.ts
+++ b/tests/integration/pox/stacking/pooled-stacking.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksTestnet } from "@stacks/network";
 import { Accounts, Constants } from "../../constants";
 import {
@@ -10,6 +7,7 @@ import {
   broadcastSTXTransfer,
   buildDevnetNetworkOrchestrator,
   getNetworkIdFromEnv,
+  getStacksNodeVersion,
   waitForStacksTransaction,
 } from "../../helpers";
 import {
@@ -33,12 +31,7 @@ import { uintCV } from "@stacks/transactions";
 
 describe("testing pooled stacking under epoch 2.1", () => {
   let orchestrator: DevnetNetworkOrchestrator;
-  let version: string;
-  if (typeof stacksNodeVersion === "function") {
-    version = stacksNodeVersion();
-  } else {
-    version = "2.1";
-  }
+  const version = getStacksNodeVersion();
   const fee = 1000;
   const timeline = {
     ...DEFAULT_EPOCH_TIMELINE,

--- a/tests/integration/traits/trait-parameter-20-20.spec.ts
+++ b/tests/integration/traits/trait-parameter-20-20.spec.ts
@@ -1,7 +1,6 @@
 import {
   DevnetNetworkOrchestrator,
   StacksTransactionMetadata,
-  stacksNodeVersion,
 } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
 import {

--- a/tests/integration/traits/trait-parameter-20-21.spec.ts
+++ b/tests/integration/traits/trait-parameter-20-21.spec.ts
@@ -1,7 +1,6 @@
 import {
   DevnetNetworkOrchestrator,
   StacksTransactionMetadata,
-  stacksNodeVersion,
 } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
 import {

--- a/tests/integration/traits/trait-parameter-20-22.spec.ts
+++ b/tests/integration/traits/trait-parameter-20-22.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
 import {
   AnchorMode,

--- a/tests/integration/traits/trait-parameter-20-23.spec.ts
+++ b/tests/integration/traits/trait-parameter-20-23.spec.ts
@@ -1,7 +1,6 @@
 import {
   DevnetNetworkOrchestrator,
   StacksTransactionMetadata,
-  stacksNodeVersion,
 } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
 import {

--- a/tests/integration/traits/trait-parameter-21-20.spec.ts
+++ b/tests/integration/traits/trait-parameter-21-20.spec.ts
@@ -1,7 +1,6 @@
 import {
   DevnetNetworkOrchestrator,
   StacksTransactionMetadata,
-  stacksNodeVersion,
 } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
 import {

--- a/tests/integration/traits/trait-parameter-21-21.spec.ts
+++ b/tests/integration/traits/trait-parameter-21-21.spec.ts
@@ -1,7 +1,6 @@
 import {
   DevnetNetworkOrchestrator,
   StacksTransactionMetadata,
-  stacksNodeVersion,
 } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
 import {

--- a/tests/integration/traits/trait-parameter-21-22.spec.ts
+++ b/tests/integration/traits/trait-parameter-21-22.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
 import {
   AnchorMode,

--- a/tests/integration/traits/trait-parameter-21-23.spec.ts
+++ b/tests/integration/traits/trait-parameter-21-23.spec.ts
@@ -1,7 +1,6 @@
 import {
   DevnetNetworkOrchestrator,
   StacksTransactionMetadata,
-  stacksNodeVersion,
 } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
 import {

--- a/tests/integration/traits/trait-parameter-22-20.spec.ts
+++ b/tests/integration/traits/trait-parameter-22-20.spec.ts
@@ -1,7 +1,6 @@
 import {
   DevnetNetworkOrchestrator,
   StacksTransactionMetadata,
-  stacksNodeVersion,
 } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
 import {

--- a/tests/integration/traits/trait-parameter-22-21.spec.ts
+++ b/tests/integration/traits/trait-parameter-22-21.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
 import {
   AnchorMode,

--- a/tests/integration/traits/trait-parameter-22-22.spec.ts
+++ b/tests/integration/traits/trait-parameter-22-22.spec.ts
@@ -1,7 +1,4 @@
-import {
-  DevnetNetworkOrchestrator,
-  stacksNodeVersion,
-} from "@hirosystems/stacks-devnet-js";
+import { DevnetNetworkOrchestrator } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
 import {
   AnchorMode,

--- a/tests/integration/traits/trait-parameter-22-23.spec.ts
+++ b/tests/integration/traits/trait-parameter-22-23.spec.ts
@@ -1,7 +1,6 @@
 import {
   DevnetNetworkOrchestrator,
   StacksTransactionMetadata,
-  stacksNodeVersion,
 } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
 import {

--- a/tests/integration/traits/trait-parameter-23-20.spec.ts
+++ b/tests/integration/traits/trait-parameter-23-20.spec.ts
@@ -1,7 +1,6 @@
 import {
   DevnetNetworkOrchestrator,
   StacksTransactionMetadata,
-  stacksNodeVersion,
 } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
 import {

--- a/tests/integration/traits/trait-parameter-23-21.spec.ts
+++ b/tests/integration/traits/trait-parameter-23-21.spec.ts
@@ -1,7 +1,6 @@
 import {
   DevnetNetworkOrchestrator,
   StacksTransactionMetadata,
-  stacksNodeVersion,
 } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
 import {

--- a/tests/integration/traits/trait-parameter-23-22.spec.ts
+++ b/tests/integration/traits/trait-parameter-23-22.spec.ts
@@ -1,7 +1,6 @@
 import {
   DevnetNetworkOrchestrator,
   StacksTransactionMetadata,
-  stacksNodeVersion,
 } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
 import {

--- a/tests/integration/traits/trait-parameter-23-23.spec.ts
+++ b/tests/integration/traits/trait-parameter-23-23.spec.ts
@@ -1,7 +1,6 @@
 import {
   DevnetNetworkOrchestrator,
   StacksTransactionMetadata,
-  stacksNodeVersion,
 } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
 import {

--- a/tests/integration/traits/traits-across-contracts.spec.ts
+++ b/tests/integration/traits/traits-across-contracts.spec.ts
@@ -1,7 +1,6 @@
 import {
   DevnetNetworkOrchestrator,
   StacksTransactionMetadata,
-  stacksNodeVersion,
 } from "@hirosystems/stacks-devnet-js";
 import { StacksNetwork, StacksTestnet } from "@stacks/network";
 import {


### PR DESCRIPTION
Fix the problem where in some environment the version check failed when
the `stacksNodeVersion` function does not exist.